### PR TITLE
Update static page to match Merit's wording

### DIFF
--- a/src/srv/app/static/index.html
+++ b/src/srv/app/static/index.html
@@ -116,7 +116,7 @@
         <p>
 	  Your current bandwidth of 
 	    <span id=text_ookla_dl>25</span>/<span id=text_ookla_ul>3</span>&nbsp;Mbps
-	    <span id=text_bw_interp>is similar to other </span> households in Chicago.
+	    <span id=text_bw_interp>is similar to other </span> households in Michigan.
 	  It <span id=text_bw_fcc>exceeds</span> the "official" threshold of broadband Internet,
 	    of 25 Mbps download and 3 Mbps uploads.
 	    Your connection is <span id=text_bw_stability>stable</span> over time.
@@ -259,7 +259,7 @@
           </p>
           <p>
 	    Your network latency to Google is 
-	      <span id=text_latency_interp>similar to other</span> households in Chicago.
+	      <span id=text_latency_interp>similar to other</span> households in Michigan.
           </p>
 
 	  <p class=extras>


### PR DESCRIPTION
This changes the wording of the main page to mention the state of Michigan instead of Chicago.